### PR TITLE
Get everything booting

### DIFF
--- a/packages/kernel/src/main.rs
+++ b/packages/kernel/src/main.rs
@@ -18,22 +18,21 @@ extern "C" {
 
     #[link_name = "_vex_startup"]
     fn vex_startup();
+    
 }
 
 extern "C" fn main() -> ! {
-    unsafe {
-        let mut call_cell_guest = host_call::Guest::new_on_guest();
-        let [call_cell, ..] = call_cell_guest.take_call_cells().unwrap();
+    // unsafe {
+    //     let mut call_cell_guest = host_call::Guest::new_on_guest();
+    //     let [call_cell, ..] = call_cell_guest.take_call_cells().unwrap();
         
-        let mut written = 0;
+    //     let mut written = 0;
 
-        let call_cell = call_cell.perform(host_call::Call::Write {
-            data: "Hello, World!".as_bytes(),
-            written: &mut written,
-        });
-
-        loop {}
-    }
+    //     let call_cell = call_cell.perform(host_call::Call::Write {
+    //         data: "Hello, World!".as_bytes(),
+    //         written: &mut written,
+    //     });
+    // }
 
     unsafe {
         vex_startup();
@@ -50,7 +49,13 @@ global_asm!(
 
     _start:
         ldr sp, =0x10000
-        bl {main}
+        mrc p15, 0x0, r1, c1, c0, 0x2
+        orr r1, r1, #0xf00000
+        mcr p15, 0x0, r1, c1, c0, 0x2
+        mrc p10, 0x7, r1, c8, c0, 0x0
+        orr r1, r1, #0x40000000
+        mcr p10, 0x7, r1, c8, c0, 0x0
+        b {main}
     "#,
     main = sym main
 );

--- a/packages/kernel/src/main.rs
+++ b/packages/kernel/src/main.rs
@@ -22,17 +22,17 @@ extern "C" {
 }
 
 extern "C" fn main() -> ! {
-    // unsafe {
-    //     let mut call_cell_guest = host_call::Guest::new_on_guest();
-    //     let [call_cell, ..] = call_cell_guest.take_call_cells().unwrap();
+    unsafe {
+        let mut call_cell_guest = host_call::Guest::new_on_guest();
+        let [call_cell, ..] = call_cell_guest.take_call_cells().unwrap();
         
-    //     let mut written = 0;
+        let mut written = 0;
 
-    //     let call_cell = call_cell.perform(host_call::Call::Write {
-    //         data: "Hello, World!".as_bytes(),
-    //         written: &mut written,
-    //     });
-    // }
+        let call_cell = call_cell.perform(host_call::Call::Write {
+            data: "Hello, World!".as_bytes(),
+            written: &mut written,
+        });
+    }
 
     unsafe {
         vex_startup();

--- a/packages/kernel/src/sdk/mod.rs
+++ b/packages/kernel/src/sdk/mod.rs
@@ -59,7 +59,7 @@ pub static mut JUMP_TABLE: [*const (); 0x1000] = {
         0x190 => get_num_devices,
         0x194 => get_num_devices_by_type,
         0x198 => devices,
-        0x18c => device_by_index,
+        0x19c => device_by_index,
         0x1a0 => device_status,
         0x1a4 => controller_channel,
         0x1a8 => controller_connection_status,
@@ -284,6 +284,8 @@ pub static mut JUMP_TABLE: [*const (); 0x1000] = {
         0x8ac => serial_write_free,
         0x8c0 => system_timer_stop,
         0x8c4 => system_timer_clear_interrupt,
+        0x8d0 => system_watchdog_reinit_rtos,
+        0x8d4 => system_watchdog_get,
         0x990 => read_bmp_image,
         0x994 => read_png_image,
         //TODO: usd functions
@@ -353,6 +355,14 @@ pub unsafe extern "C" fn enable_system_timer(param_1: u32) -> u32 {
     0
 }
 pub unsafe extern "C" fn disable_system_timer(param_1: u32) {}
+
+pub unsafe extern "C" fn system_watchdog_reinit_rtos() -> i32 { 
+    0
+}
+
+pub unsafe extern "C" fn system_watchdog_get() -> u32 {
+    0
+}
 
 pub unsafe extern "C" fn usb_status() -> u32 {
     1

--- a/packages/simulator/src/main.rs
+++ b/packages/simulator/src/main.rs
@@ -31,8 +31,8 @@ fn main() {
     let opt = <Opt as clap::Parser>::parse();
 
     let mut qemu = Command::new("qemu-system-arm")
-        .args(&["-machine", "none,memory-backend=mem"])
-        .args(&["-cpu", "cortex-a7"])
+        .args(&["-machine", "xilinx-zynq-a9,memory-backend=mem"])
+        .args(&["-cpu", "cortex-a9"])
         .args(&[
             "-object",
             "memory-backend-file,id=mem,size=256M,mem-path=/dev/shm/v5-simulator",
@@ -54,10 +54,11 @@ fn main() {
         //     "-chardev",
         //     "stdio,id=simmonitor,signal=off",
         // ])
-        // .stdin(Stdio::piped())
-        // .stdout(Stdio::piped())
+        //.stdin(Stdio::piped())
+        //.stdout(Stdio::piped())
         .stderr(Stdio::inherit())
-        .args(&["-nographic", "-S"])
+        .args(&["-S"])
+        .args(&["-s"])
         .spawn()
         .expect("Failed to start QEMU.");
 


### PR DESCRIPTION
Made the necessary modifications to both the kernel and simulator to allow for actual program booting. Specifically:
- The QEMU instance is now created as a simulated xilinx-zynq-a9, along with a few other tweaks to the vm settings to allow everything to function.
- On boot, the kernel will now enable the FPU and will actually jump to the beginning of the program.

Not enough jump table functions are implemented to actually run a user program yet, but this PR makes a huge step towards that goal.
